### PR TITLE
Don't break if a directory without `package.json` matches.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,4 +18,5 @@ rules:
     - devDependencies:
       - scripts/**
       - __tests__/**
+  no-param-reassign: 0
   no-underscore-dangle: 0

--- a/__tests__/fixtures/packageFour/plackage.json
+++ b/__tests__/fixtures/packageFour/plackage.json
@@ -1,0 +1,3 @@
+{
+  "name": "package-four"
+}

--- a/src/readPkgs.js
+++ b/src/readPkgs.js
@@ -15,17 +15,17 @@ export default function readPkgs(
   patterns: string | Array<string>,
   options?: ReadPkgsOptions = {},
 ): Promise<Array<{directory: string, pkg: Object}>> {
-  if (
-    typeof patterns !== 'string' &&
-    !(
-      Array.isArray(patterns) &&
-      patterns.every(pattern => typeof pattern === 'string')
-    )
+  if (typeof patterns === 'string') {
+    patterns = [patterns];
+  } else if (
+    !Array.isArray(patterns) ||
+    patterns.some(pattern => typeof pattern !== 'string')
   ) {
     return Promise.reject(
       new Error('"patterns" must be a string or an array of strings.'),
     );
   }
+
   if (!isobject(options)) {
     return Promise.reject(
       new Error('"options" must be a ReadPkgsOptions object or undefined.'),
@@ -41,13 +41,15 @@ export default function readPkgs(
 
   return getStream.array(
     fastGlob
-      .stream(patterns, {cwd, onlyDirectories: true, onlyFiles: false})
+      .stream(patterns.map(pattern => path.join(pattern, 'package.json')), {
+        cwd,
+      })
       .pipe(
         new Transform({
           objectMode: true,
           transform(directory, encoding, callback) {
             readPkg(path.resolve(cwd, directory), {normalize}).then(pkg =>
-              callback(null, {directory, pkg}),
+              callback(null, {directory: path.dirname(directory), pkg}),
             );
           },
         }),


### PR DESCRIPTION
Pretty sure this isn't the right way to do globs, just handling a bunch of ENOENT doesn't feel right, either.